### PR TITLE
Use float to store Digitizer "poll_rate" value

### DIFF
--- a/lib/flowgraph_impl.cc
+++ b/lib/flowgraph_impl.cc
@@ -745,8 +745,8 @@ struct Ps3000aMaker : BlockMaker
         }
 
         if (acquisition_mode == "Streaming") {
-            auto buff_size = info.eval_param_value<int>("buff_size", variables);
-            auto poll_rate = info.eval_param_value<int>("poll_rate", variables);
+            int buff_size = info.eval_param_value<int>("buff_size", variables);
+            float poll_rate = info.eval_param_value<float>("poll_rate", variables);
             ps->set_buffer_size(buff_size);
             ps->set_streaming(poll_rate);
         }
@@ -876,8 +876,8 @@ struct Ps4000aMaker : BlockMaker
         }
 
         if (acquisition_mode == "Streaming") {
-            auto buff_size = info.eval_param_value<int>("buff_size", variables);
-            auto poll_rate = info.eval_param_value<int>("poll_rate", variables);
+            int buff_size = info.eval_param_value<int>("buff_size", variables);
+            float poll_rate = info.eval_param_value<float>("poll_rate", variables);
             ps->set_buffer_size(buff_size);
             ps->set_streaming(poll_rate);
         }
@@ -965,8 +965,8 @@ struct Ps6000Maker : BlockMaker
         }
 
         if (acquisition_mode == "Streaming") {
-            auto buff_size = info.eval_param_value<int>("buff_size", variables);
-            auto poll_rate = info.eval_param_value<int>("poll_rate", variables);
+            int buff_size = info.eval_param_value<int>("buff_size", variables);
+            float poll_rate = info.eval_param_value<float>("poll_rate", variables);
             ps->set_buffer_size(buff_size);
             ps->set_streaming(poll_rate);
         }


### PR DESCRIPTION
Fixes https://github.com/fair-acc/gr-digitizers/issues/53

... just realized that poll_rate internally is just always 0 while working on https://github.com/fair-acc/gr-digitizers/pull/92  and took a closer look on where it gets currupted

So it looks like Digitizers so far were always polled "as fast as possible"

Tested with dal018 which seems to run fine after the change (poll rate 0,001 --> 1ms) ... printed the poll-rate in ms during debugging to make sure it is correct now.